### PR TITLE
update to nightly 8-22

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,6 @@ homepage = "https://github.com/danielrs/ao-rs"
 documentation = "https://github.com/danielrs/ao-rs"
 repository = "https://github.com/danielrs/ao-rs"
 
-license = "GPL-3.0"
 license-file = "./LICENSE"
 
 [dependencies]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -95,11 +95,15 @@ impl Device {
         let ao_device =
             unsafe { ffi::ao_open_live(driver.driver_id(), &format.to_ao_format(), options) };
 
-        if ao_device.is_null() {
-            Err(Error::from_errno())
-        } else {
-            unsafe { Ok(Device { device: Unique::new(ao_device) }) }
-        }
+        // unique new does a null-ptr check now
+        let ao_device = match Unique::new(ao_device) {
+            Some(udev) => udev,
+            None => {
+                return Err(Error::from_errno())
+            }
+        };
+
+        Ok(Device { device: ao_device })
     }
 
     /// Plays the given PCM data using the specified format.


### PR DESCRIPTION
Adapt to Unique interface updates in nightly
Remove cargo warnings for duplicate license specification